### PR TITLE
Added indexing and down-one command

### DIFF
--- a/packages/drizzle-migrations/package.json
+++ b/packages/drizzle-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drepkovsky/drizzle-migrations",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Tiny tool for managing migrations in Drizzle",
   "scripts": {
     "build": "rimraf dist && tsup",

--- a/packages/drizzle-migrations/src/cli-entry.ts
+++ b/packages/drizzle-migrations/src/cli-entry.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander'
 import toKebabCase from 'lodash.kebabcase'
 import toSnakeCase from 'lodash.snakecase'
 import { MigrationDownCommand } from './commands/migration-down.command'
+import { MigrationDownOneCommand } from './commands/migration-down-one.command'
 import { MigrationGenerateCommand } from './commands/migration-generate.command'
 import { MigrationStatusCommand } from './commands/migration-status.command'
 import { MigrationUpCommand } from './commands/migration-up.command'
@@ -77,6 +78,16 @@ program
     await command.run()
     process.exit(0)
   })
+
+  program
+    .command("down-one")
+    .description("Rollback only the migration with the highest index")
+    .action(async () => {
+      const ctx = await buildMigrationContext(resolveDrizzleConfig());
+      const command = new MigrationDownOneCommand(ctx);
+      await command.run();
+      process.exit(0);
+    });
 
 program
   .command('status')

--- a/packages/drizzle-migrations/src/commands/migration-down-one.command.ts
+++ b/packages/drizzle-migrations/src/commands/migration-down-one.command.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import * as tsx from "tsx/cjs/api";
+import type { ConfigDialect, Migration } from "..";
+import { startTransaction } from "../helpers/db-helpers";
+import {
+  deleteMigrationByName,
+  ensureMigrationTable,
+  getMigrationWithHighestIndex,
+} from "../helpers/migration";
+import { BaseCommand } from "./_base.command";
+
+export class MigrationDownOneCommand extends BaseCommand {
+  async run() {
+    await ensureMigrationTable(this.ctx);
+
+    const migrationNameWithHighestIndex = await getMigrationWithHighestIndex(
+      this.ctx
+    );
+
+    if (!migrationNameWithHighestIndex) {
+      // biome-ignore lint/suspicious/noConsoleLog: <explanation>
+      console.log("[Down One]: No migrations to roll back");
+      return;
+    }
+
+    await startTransaction(this.ctx, async (trx) => {
+      const migrationFile = `${migrationNameWithHighestIndex}.ts`;
+
+      const migration = tsx.require(
+        path.join(this.ctx.migrationFolder, migrationFile),
+        __filename
+      ) as Migration<ConfigDialect>;
+
+      if (!migration.down) {
+        throw new Error(
+          `Migration ${migrationNameWithHighestIndex} is missing a down function`
+        );
+      }
+
+      // biome-ignore lint/suspicious/noConsoleLog: <explanation>
+      console.log(`[Down One]: ${migrationNameWithHighestIndex} is running`);
+      await migration.down({ db: trx });
+      await deleteMigrationByName(migrationNameWithHighestIndex, {
+        ...this.ctx,
+        client: trx as any,
+      });
+      // biome-ignore lint/suspicious/noConsoleLog: <explanation>
+      console.log(
+        `[Down One]: ${migrationNameWithHighestIndex} run successfully`
+      );
+    });
+  }
+}


### PR DESCRIPTION
Closes #7 

- Added new command `down-one`
- Added serial index to `drizzle_migrations` table to indicate the order that migrations were run
- Added `MigrationDownOneCommand` to only `down` the most recent migration

